### PR TITLE
fix: derive npm publish version from release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Derive version from release tag
+        run: echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
       - uses: actions/setup-node@v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - name: Set package version from tag
+        run: echo $(jq --arg v "${{ env.VERSION }}" '(.version) = $v' package.json) > package.json
+
       - run: npm ci
+
+      - run: npm run build
 
       - name: Publish release candidate
         if: github.event.release.prerelease

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstash/cli",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Agent-friendly CLI for Upstash",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release workflow published the literal `package.json` version, not the tag — so they drifted (`v0.4.0-rc.1` shipped to npm as `1.0.0`). Now derives the version from the git tag and keeps `package.json` at a `0.0.0` placeholder, like qstash-cli.