### PR TITLE
fix: read legacy ~/.upstash.json so 0.x users stay logged in

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,8 +20,16 @@ export function getConfigPath(): string {
   return join(getConfigDir(), "config.json");
 }
 
-export function readConfig(): Auth | null {
-  const path = getConfigPath();
+// The 0.x CLI stored credentials at ~/.upstash.json with a camelCase `apiKey`.
+// We read it as a fallback so users upgrading to 1.x stay logged in. The path
+// is overridable for tests, mirroring UPSTASH_CONFIG_HOME.
+export function getLegacyConfigPath(): string {
+  const override = process.env.UPSTASH_LEGACY_CONFIG_HOME;
+  const base = override && override.length > 0 ? override : homedir();
+  return join(base, ".upstash.json");
+}
+
+function readConfigFile(path: string): Auth | null {
   if (!existsSync(path)) return null;
   let raw: string;
   try {
@@ -29,14 +37,20 @@ export function readConfig(): Auth | null {
   } catch {
     return null;
   }
-  let parsed: StoredConfig;
+  let parsed: StoredConfig & { apiKey?: string };
   try {
-    parsed = JSON.parse(raw) as StoredConfig;
+    parsed = JSON.parse(raw) as StoredConfig & { apiKey?: string };
   } catch {
     return null;
   }
-  if (!parsed.email || !parsed.api_key) return null;
-  return { email: parsed.email, apiKey: parsed.api_key };
+  // Accept the new snake_case `api_key` or the legacy camelCase `apiKey`.
+  const apiKey = parsed.api_key ?? parsed.apiKey;
+  if (!parsed.email || !apiKey) return null;
+  return { email: parsed.email, apiKey };
+}
+
+export function readConfig(): Auth | null {
+  return readConfigFile(getConfigPath()) ?? readConfigFile(getLegacyConfigPath());
 }
 
 export function writeConfig(auth: Auth): string {

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -3,7 +3,8 @@ import { mkdtempSync, rmSync, statSync, readFileSync, existsSync } from "node:fs
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
-import { readConfig, writeConfig, deleteConfig, getConfigPath } from "../../src/config.js";
+import { writeFileSync } from "node:fs";
+import { readConfig, writeConfig, deleteConfig, getConfigPath, getLegacyConfigPath } from "../../src/config.js";
 import { resolveAuth } from "../../src/auth.js";
 import { registerLogin } from "../../src/commands/login.js";
 import { registerLogout } from "../../src/commands/logout.js";
@@ -14,6 +15,7 @@ const originalEnv = { ...process.env };
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "upstash-cli-test-"));
   process.env.UPSTASH_CONFIG_HOME = dir;
+  process.env.UPSTASH_LEGACY_CONFIG_HOME = dir;
   delete process.env.UPSTASH_EMAIL;
   delete process.env.UPSTASH_API_KEY;
 });
@@ -45,6 +47,28 @@ describe("config file round-trip", () => {
     writeConfig({ email: "a@b.com", apiKey: "key-1" });
     expect(deleteConfig()).toBe(true);
     expect(existsSync(getConfigPath())).toBe(false);
+  });
+});
+
+describe("legacy ~/.upstash.json fallback", () => {
+  function writeLegacy(body: unknown): void {
+    writeFileSync(getLegacyConfigPath(), JSON.stringify(body));
+  }
+
+  it("reads the 0.x file (camelCase apiKey) when no new config exists", () => {
+    writeLegacy({ email: "legacy@b.com", apiKey: "legacy-key" });
+    expect(readConfig()).toEqual({ email: "legacy@b.com", apiKey: "legacy-key" });
+  });
+
+  it("prefers the new config over the legacy file", () => {
+    writeLegacy({ email: "legacy@b.com", apiKey: "legacy-key" });
+    writeConfig({ email: "new@b.com", apiKey: "new-key" });
+    expect(readConfig()).toEqual({ email: "new@b.com", apiKey: "new-key" });
+  });
+
+  it("ignores a legacy file that is missing a field", () => {
+    writeLegacy({ email: "legacy@b.com" });
+    expect(readConfig()).toBeNull();
   });
 });
 


### PR DESCRIPTION
The 1.0 rewrite moved saved credentials from `~/.upstash.json` to `~/.config/upstash/config.json` and renamed the JSON key `apiKey` to `api_key`. As a result, anyone upgrading from the 0.x CLI silently appears logged out (and any script passing the old `-c/--config` flag already errors).

This adds a read-only fallback so existing users keep working:

- `readConfig()` now reads the new config first, then falls back to the legacy `~/.upstash.json`, accepting either the new `api_key` or the legacy `apiKey`.
- The new config always wins, so the first `upstash login` transparently migrates a user onto the new path.
- The legacy path is overridable via `UPSTASH_LEGACY_CONFIG_HOME` (mirrors `UPSTASH_CONFIG_HOME`) purely so tests stay isolated.

Scope is intentionally small: this is read-only. We never write or delete `~/.upstash.json` (`upstash logout` still only manages the new file).

Tests: 3 new unit tests cover the legacy read, new-over-legacy precedence, and a malformed legacy file. Typecheck + build + unit suite green.