### PR TITLE
DX-2866: add `upstash start-redis` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ For agents, pair the CLI with the [Upstash Skill](https://docs.upstash.com/agent
 npx skills add upstash/skills
 ```
 
+## No account? Start with a free Redis
+
+If you are an AI agent (or just want to try things out) and need a Redis DB to use or experiment with, you don't need an Upstash account:
+
+```bash
+upstash start-redis
+```
+
+This prints markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Pass `--id <database-id>` to re-fetch the credentials of a database you created earlier. Everything else in this CLI needs authentication.
+
 ## Authentication
 
 Grab a Developer API key from the [Upstash Console](https://console.upstash.com/account/api), then save it once per machine:
@@ -29,10 +39,11 @@ Or set `UPSTASH_EMAIL` and `UPSTASH_API_KEY` in your shell or a `.env` file. See
 
 ## Quick examples
 
-All output is JSON, so you can pipe to `jq`. Use `--dry-run` to preview destructive commands.
+All output is JSON, so you can pipe to `jq` (the one exception is `start-redis`, which prints markdown). Use `--dry-run` to preview destructive commands.
 
 ```bash
 # Redis
+upstash start-redis  # free temporary DB, no account needed
 upstash redis list
 upstash redis create --name my-db --region us-east-1
 upstash redis exec --db-url $URL --db-token $TOKEN GET key

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you are an AI agent (or just want to try things out) and need a Redis DB to u
 upstash start-redis
 ```
 
-This prints markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Pass `--id <database-id>` to re-fetch the credentials of a database you created earlier. Everything else in this CLI needs authentication.
+This prints markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Pass `--id <database-id>` to re-fetch the credentials of a database you created earlier. Every command that touches your Upstash account needs authentication — only `start-redis` and the `login`/`logout` credential helpers do not.
 
 ## Authentication
 
@@ -39,7 +39,7 @@ Or set `UPSTASH_EMAIL` and `UPSTASH_API_KEY` in your shell or a `.env` file. See
 
 ## Quick examples
 
-All output is JSON, so you can pipe to `jq` (the one exception is `start-redis`, which prints markdown). Use `--dry-run` to preview destructive commands.
+Every command that returns account data outputs JSON, so you can pipe to `jq`. The exceptions are `start-redis`, which prints markdown, and `login`/`logout`, which print a plain-text confirmation. Use `--dry-run` to preview destructive commands.
 
 ```bash
 # Redis

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { registerSearch } from "./commands/search/index.js";
 import { registerQStash } from "./commands/qstash/index.js";
 import { registerLogin } from "./commands/login.js";
 import { registerLogout } from "./commands/logout.js";
+import { registerStartRedis } from "./commands/start-redis.js";
 import { handleError } from "./output.js";
 import dotenv from "dotenv";
 
@@ -39,6 +40,7 @@ program
 
 registerLogin(program);
 registerLogout(program);
+registerStartRedis(program);
 registerRedis(program);
 registerTeam(program);
 registerVector(program);

--- a/src/commands/redis/create.ts
+++ b/src/commands/redis/create.ts
@@ -9,7 +9,7 @@ export function registerCreate(redis: Command): void {
   redis
     .command("create")
     .description(
-      "Create a new Redis database. Needs an Upstash account; for a free throwaway database with no account, use `upstash start-redis`.",
+      "Create a new Redis database. Needs an Upstash account; for a free throwaway database with no account, use the start-redis command.",
     )
     .requiredOption("--name <name>", "Database name")
     .requiredOption("--region <region>", `Primary region. Available: ${REGIONS.join(", ")}`)

--- a/src/commands/redis/create.ts
+++ b/src/commands/redis/create.ts
@@ -8,7 +8,9 @@ import type { Database } from "../../types.js";
 export function registerCreate(redis: Command): void {
   redis
     .command("create")
-    .description("Create a new Redis database")
+    .description(
+      "Create a new Redis database. Needs an Upstash account; for a free throwaway database with no account, use `upstash start-redis`.",
+    )
     .requiredOption("--name <name>", "Database name")
     .requiredOption("--region <region>", `Primary region. Available: ${REGIONS.join(", ")}`)
     .option("--read-regions <regions...>", "Read replica regions (space-separated)")

--- a/src/commands/start-redis.ts
+++ b/src/commands/start-redis.ts
@@ -11,12 +11,20 @@ export function registerStartRedis(program: Command): void {
     )
     .option("--id <id>", "Re-fetch the credentials of a database created earlier")
     .action(async (flags: { id?: string }) => {
-      const response = await fetch(START_REDIS_URL, {
-        method: "POST",
-        headers: flags.id ? { "Idempotency-Key": flags.id } : undefined,
-      });
-
-      const text = await response.text();
+      // This command's output is markdown, not JSON, so network failures are
+      // reported as plain text too rather than through the JSON error path.
+      let response: Response;
+      let text: string;
+      try {
+        response = await fetch(START_REDIS_URL, {
+          method: "POST",
+          headers: flags.id ? { "Idempotency-Key": flags.id } : undefined,
+        });
+        text = await response.text();
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw plainError(`Could not reach ${START_REDIS_URL}: ${reason}`);
+      }
 
       if (!response.ok) {
         throw plainError(text || `HTTP ${response.status}`);

--- a/src/commands/start-redis.ts
+++ b/src/commands/start-redis.ts
@@ -1,0 +1,27 @@
+import { Command } from "commander";
+import { plainError } from "../output.js";
+
+const START_REDIS_URL = "https://upstash.com/start-redis";
+
+export function registerStartRedis(program: Command): void {
+  program
+    .command("start-redis")
+    .description(
+      "Get a free temporary Redis database — no account or API key needed. Prints markdown with credentials and a quickstart. Expires in 72 hours; claim it with an Upstash account to keep it.",
+    )
+    .option("--id <id>", "Re-fetch the credentials of a database created earlier")
+    .action(async (flags: { id?: string }) => {
+      const response = await fetch(START_REDIS_URL, {
+        method: "POST",
+        headers: flags.id ? { "Idempotency-Key": flags.id } : undefined,
+      });
+
+      const text = await response.text();
+
+      if (!response.ok) {
+        throw plainError(text || `HTTP ${response.status}`);
+      }
+
+      console.log(text.trimEnd());
+    });
+}

--- a/tests/unit/start-redis.test.ts
+++ b/tests/unit/start-redis.test.ts
@@ -53,6 +53,14 @@ describe("start-redis", () => {
     expect(init?.headers).toEqual({ "Idempotency-Key": "db-123" });
   });
 
+  it("throws a plain error when the network is unreachable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+
+    await expect(run(["start-redis"])).rejects.toThrow(
+      "Could not reach https://upstash.com/start-redis: getaddrinfo ENOTFOUND",
+    );
+  });
+
   it("throws a plain error when the request fails", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("rate limited", { status: 429 }),

--- a/tests/unit/start-redis.test.ts
+++ b/tests/unit/start-redis.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { registerStartRedis } from "../../src/commands/start-redis.js";
+
+const MARKDOWN = "# Your Redis is ready\n\n**Endpoint:** https://example.upstash.io\n";
+
+function createProgram(): Command {
+  const program = new Command().exitOverride();
+  registerStartRedis(program);
+  return program;
+}
+
+async function run(argv: string[]): Promise<string[]> {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    await createProgram().parseAsync(["node", "upstash", ...argv]);
+  } finally {
+    console.log = origLog;
+  }
+  return output;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("start-redis", () => {
+  it("POSTs without credentials and prints the markdown response", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(MARKDOWN, { status: 200 }));
+
+    const output = await run(["start-redis"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://upstash.com/start-redis");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toBeUndefined();
+    expect(output).toEqual([MARKDOWN.trimEnd()]);
+  });
+
+  it("sends the database id as an idempotency key when --id is given", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(MARKDOWN, { status: 200 }));
+
+    await run(["start-redis", "--id", "db-123"]);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init?.headers).toEqual({ "Idempotency-Key": "db-123" });
+  });
+
+  it("throws a plain error when the request fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("rate limited", { status: 429 }),
+    );
+
+    await expect(run(["start-redis"])).rejects.toThrow("rate limited");
+  });
+});


### PR DESCRIPTION
Adds an unauthenticated top-level command that POSTs to https://upstash.com/start-redis and prints the returned markdown (credentials + quickstart). `--id` re-fetches an earlier database via the Idempotency-Key header.

Also surfaces it from the README and from `upstash redis create --help`.